### PR TITLE
add --all switch to get _all_ reference bases back in the masked cons…

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -93,6 +93,7 @@ def helpMSG() {
      ${c_blue}--motif X ${c_reset}      Upstream and Downstream length of sequence Motif [default: $params.motif]
 
     ${c_yellow}Options  (optional)${c_reset}
+     --all           Output absolutely all positions, including references with no data aligned against them [default: $params.all]
      --cores         Amount of cores for a process (local use) [default: $params.cores]
      --max_cores     Max amount of cores for poreCov to use (local use) [default: $params.max_cores]
      --memory        Available memory [default: $params.memory]

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,6 @@ params {
     memory = "16"
     profile = false
     help = false
-    all = false
 
 // inputs
     fastq = ''
@@ -19,6 +18,7 @@ params {
     frequency = false
     depth = "10"
     motif = "5"
+    keep_coordinates = false
 
 
 // folder structure

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params {
     memory = "16"
     profile = false
     help = false
+    all = false
 
 // inputs
     fastq = ''

--- a/workflows/process/minimap2.nf
+++ b/workflows/process/minimap2.nf
@@ -7,13 +7,13 @@ process minimap2 {
     	tuple val(name), file("${name}.masked.fasta"), env(MASKREGIONS), emit: fasta
         tuple val(name), file("${name}.masked.sorted.bam"), emit: bam
   	script:
-    if (params.all) {
+    if (params.keep_coordinates) {
     """
     minimap2 -t ${task.cpus} -o ${name}.sam -ax map-ont ${fasta} ${reads}
     samtools view -bS ${name}.sam | samtools sort - -@ ${task.cpus} -o ${name}.minimap.sorted.bam
 
     # consensus
-    samtools consensus -aa -@ ${task.cpus} -f fasta -X r10.4_sup ${name}.minimap.sorted.bam -o ${name}.masked.fasta
+    samtools consensus -aa --show-ins no --show-del no -@ ${task.cpus} -f fasta -X r10.4_sup ${name}.minimap.sorted.bam -o ${name}.masked.fasta
     rm ${name}.minimap.sorted.bam ${name}.sam
 
     # get Masked Bases
@@ -61,13 +61,14 @@ process minimap2_degen {
     	tuple val(name), path("${name}.masked.fasta"), path("${name}_depth_file.txt"), emit: fasta
         tuple val(name), path("${name}.masked.sorted.bam"), emit: bam
   	script:
-    if (params.all) {
+    if (params.keep_coordinates) {
     """
     minimap2 -t ${task.cpus} -o ${name}.sam -ax map-ont ${fasta} ${reads}
     samtools view -bS ${name}.sam | samtools sort - -@ ${task.cpus} -o ${name}.minimap.sorted.bam
 
     # consensus
-    samtools consensus -aa -@ ${task.cpus} \
+    samtools consensus -aa --show-ins no --show-del no \
+                        -@ ${task.cpus} \
                         --ambig \
                         -f fasta  \
                         -X r10.4_sup \


### PR DESCRIPTION
…ensus. Preventing positions shift (except INDELs)

This should be the main step to solve #4 

There is more that could be advanced, e.g. special handling of INDELs that also make it impossible to easily match between input FASTA and consensus FASTA coordinates. 

See:

https://www.htslib.org/doc/samtools-consensus.html

```
 --show-del yes/no
 Whether to show deletions as "*" (no) or to omit from the output (yes). Defaults to no. 

--show-ins yes/no
 Whether to show insertions in the consensus. Defaults to yes. 

--mark-ins
Insertions, when shown, are normally recorded in the consensus with plain 7-bit ASCII (ACGT, or acgt if heterozygous). However this makes it impossible to identify the mapping between consensus coordinates and the original reference coordinates. If fasta output is selected then the option adds an underscore before every inserted base, plus a corresponding character in the quality for fastq format. When used in conjunction with -a --show-del yes, this permits an easy derivation of the consensus to reference coordinate mapping.```

But for now, that should be fine and a good first switch if a user wants to have a good chance in keeping the original coordinates in the consensus. 